### PR TITLE
Patched bonerpatrol regex

### DIFF
--- a/garycode.js
+++ b/garycode.js
@@ -1,7 +1,7 @@
 const Discord = require ('discord.js');
 const bot = new Discord.Client();
 const {discord_token} = require('./config.json');
-const bonerpatrol = /^bone$|\s?[^a-z]+\bbone[^a-z]?\b|^bone[^a-z]$/i;
+const bonerpatrol = /^bone\b|\s?[^a-z]+\bbone[^a-z]?\b|^bone[^a-z]$/i;
 
 const token = discord_token;
 


### PR DESCRIPTION
Bone was not triggering if the message began with ‘bone’ and continued further with no other instance of ‘bone’. This allows a message like ‘Bone it up’ to properly trigger the response.